### PR TITLE
encode contents of OPML file

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@
 // @grant	none
 // ==/UserScript==
 
-download(buildOpmlFile(extractChannels()));
+download(encodeURIComponent(buildOpmlFile(extractChannels())));
 
 function extractChannels() {
   var channels = []


### PR DESCRIPTION
This preserves newlines and indentation in the file content, fixing #2